### PR TITLE
Issue2 assimpnet5 reference

### DIFF
--- a/CustomMeshes/CustomMeshes.csproj
+++ b/CustomMeshes/CustomMeshes.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony20">
-      <HintPath>..\..\BepInEx\0Harmony20.dll</HintPath>
+      <HintPath>..\BepInEx\0Harmony20.dll</HintPath>
     </Reference>
     <Reference Include="assembly_googleanalytics">
       <HintPath>..\valheim_Data\Managed\assembly_googleanalytics.dll</HintPath>
@@ -51,7 +51,7 @@
       <HintPath>..\..\assimpnet\AssimpNet\bin\Debug\net4\AssimpNet.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\..\BepInEx\BepInEx.dll</HintPath>
+      <HintPath>..\BepInEx\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -96,7 +96,7 @@
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\UnityEngine\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>..\valheim_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TerrainModule">
       <HintPath>..\valheim_Data\Managed\UnityEngine.TerrainModule.dll</HintPath>

--- a/CustomMeshes/CustomMeshes.csproj
+++ b/CustomMeshes/CustomMeshes.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -47,8 +49,7 @@
       <HintPath>..\valheim_Data\Managed\assembly_valheim.dll</HintPath>
     </Reference>
     <Reference Include="AssimpNet, Version=5.0.0.0, Culture=neutral, PublicKeyToken=0d51b391f59f42a6, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\assimpnet\AssimpNet\bin\Debug\net4\AssimpNet.dll</HintPath>
+      <HintPath>..\packages\AssimpNet.5.0.0-beta1\lib\net40\AssimpNet.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
       <HintPath>..\BepInEx\BepInEx.dll</HintPath>
@@ -139,4 +140,11 @@
   <PropertyGroup>
     <PostBuildEvent>call $(SolutionDir)copyDll.bat $(ProjectName)</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets" Condition="Exists('..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets'))" />
+  </Target>
 </Project>

--- a/CustomMeshes/packages.config
+++ b/CustomMeshes/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AssimpNet" version="5.0.0-beta1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Follow-up on the missing reference for **AssimpNet** from: https://github.com/aedenthorn/ValheimMods/issues/7
Added the NuGet package (pre-release) of v5.0.0.0-beta to the **CustomMeshes** project.
When getting a fresh clone and trying to build this project an error will show up mentioning the NuGet Package Manager can restore the missing package. After this is done the project compiles normally.
This includes the rel path fixes from PR https://github.com/aedenthorn/ValheimMods/pull/9, but only those applied to **CustomMeshes** to allow it to compile.