### PR TITLE
Make "Craft from Containers" work with custom containers

### DIFF
--- a/CraftFromContainers/BepInExPlugin.cs
+++ b/CraftFromContainers/BepInExPlugin.cs
@@ -184,7 +184,7 @@ namespace CraftFromContainers
             static void Postfix(Container __instance, ZNetView ___m_nview)
             {
 
-                if ((__instance.name.StartsWith("piece_chest") || __instance.name.StartsWith("Container")) && __instance.GetInventory() != null)
+                if (__instance.GetInventory() != null)
                 {
                     containerList.Add(__instance);
                 }

--- a/CraftFromContainers/BepInExPlugin.cs
+++ b/CraftFromContainers/BepInExPlugin.cs
@@ -183,7 +183,7 @@ namespace CraftFromContainers
         {
             static void Postfix(Container __instance, ZNetView ___m_nview)
             {
-	    	var piece = __instance.GetComponentInParent<Piece>();
+                var piece = __instance.GetComponentInParent<Piece>();
 
                 if (__instance.GetInventory() != null && piece != null && piece.IsPlacedByPlayer())
                 {

--- a/CraftFromContainers/BepInExPlugin.cs
+++ b/CraftFromContainers/BepInExPlugin.cs
@@ -183,8 +183,9 @@ namespace CraftFromContainers
         {
             static void Postfix(Container __instance, ZNetView ___m_nview)
             {
+	    	var piece = __instance.GetComponentInParent<Piece>();
 
-                if (__instance.GetInventory() != null)
+                if (__instance.GetInventory() != null && piece != null && piece.IsPlacedByPlayer())
                 {
                     containerList.Add(__instance);
                 }


### PR DESCRIPTION
I can be really wrong about the requirements behind your mod and checks that you're making in code.

But from the first view, it seemed that name-checking for the `Container` class is kinda redundant and prevents your mod from working with custom pieces added by other mods. I would love to have some more details about your needs to make this PR better and provide compatibility with some other mods at the same time.

I just don't know what cases are covered by this check, so, please, forgive me if it's totally unacceptable PR.