### PR TITLE
Disable track loop only when music is queued

### DIFF
--- a/CustomAudio/BepInExPlugin.cs
+++ b/CustomAudio/BepInExPlugin.cs
@@ -364,9 +364,10 @@ namespace CustomAudio
                     lastMusic = null;
                 if (___m_musicSource.isPlaying)
                 {
-                    if(___m_musicSource.loop)
+                    if (___m_queuedMusic != null && ___m_musicSource.loop) {
                         Dbgl($"queued {___m_queuedMusic?.m_name}, setting {___m_musicSource.name} loop to false");
-                    ___m_musicSource.loop = false;
+                        ___m_musicSource.loop = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolves NexusMods issue:  "Infinite attempts to play Home music at same seek point"