### PR TITLE
Fix conflict with EquipmentAndQuickSlots mod

### DIFF
--- a/SimpleSort/BepInExPlugin.cs
+++ b/SimpleSort/BepInExPlugin.cs
@@ -210,14 +210,19 @@ namespace SimpleSort
                 {
                     int amount = Mathf.Min(items[i].m_shared.m_maxStackSize - items[i].m_stack, items[i + 1].m_stack);
                     items[i].m_stack += amount;
-                    if (amount == items[i + 1].m_stack)
-                    {
-                        items.RemoveAt(i + 1);
-                    }
-                    else
+                    if (amount == items[i + 1].m_stack) {
                         items[i + 1].m_stack -= amount;
+                        items.RemoveAt(i+1);
+                        
+                        // Dummy call, only using it to remove all items from inventory where stack size <= 0
+                        // This needs to be done because the reference to the original items list gets broken somehow when using EquipmentAndQuickSlots mod
+                        Traverse.Create(inventory).Method("RemoveItem", new object[]{"", 0}).GetValue();
+                    } else {
+                        items[i + 1].m_stack -= amount;
+                    }
                 }
             }
+            
             switch (type)
             {
                 case SortType.Name:


### PR DESCRIPTION
This solves the issue with partial stacks multiplying when the EquipmentAndQuickSlots mod is installed.

These bugs are mentioned on the mod page: https://www.nexusmods.com/valheim/mods/584?tab=bugs

It seems that the reference to the inventory item is broken at some point, so the items.RemoveAt(i+1) call only affects the items list locally, and not in the Inventory. The references to the items within the list are intact though, so modifying the counts still works. This means that adding one stack to another successfully updates the counts, but the removal of the item from the list fails, therefore items have been duplicated.

I fixed this by decrementing the counts to 0, and then calling the Inventory.RemoveItem(string, int) method which is only needed because it removes stacks of 0 or less. 

This resolves the duplication! Maybe not the cleanest but this is my first time touching Valheim mods. Hopefully this at least helps solve the issue.