### PR TITLE
Fix for Crafting Items with recipe requirements more than the max stack size

### DIFF
--- a/CraftFromContainers/BepInExPlugin.cs
+++ b/CraftFromContainers/BepInExPlugin.cs
@@ -772,10 +772,14 @@ namespace CraftFromContainers
                                     ItemDrop.ItemData item = cInventory.GetItem(i);
                                     if(item.m_shared.m_name == reqName)
                                     {
+                                        Dbgl($"Container has a total items count of {cInventory.GetAllItems().Count}");
                                         Dbgl($"Got stack of {item.m_stack} {reqName}");
                                         int stackAmount = Mathf.Min(item.m_stack, totalRequirement - totalAmount);
                                         if (stackAmount == item.m_stack)
-                                            cInventory.RemoveItem(item);
+                                        {
+                                            cInventory.RemoveItem(i);
+                                            i--;
+                                        }
                                         else
                                             item.m_stack -= stackAmount;
 


### PR DESCRIPTION
This fix is for recipes with non-stackable item requirements and for recipes that has a requirement set to more than the max stack size (e.g crafting a club that needs 75 wood to craft with a stack size of 50)