### PR TITLE
Improve life quality

### DIFF
--- a/ExtendedPlayerInventory/BepInExPlugin.cs
+++ b/ExtendedPlayerInventory/BepInExPlugin.cs
@@ -69,7 +69,7 @@ namespace ExtendedPlayerInventory
             nexusID.Value = 1356;
 
 
-            extraRows = Config.Bind<int>("Toggles", "ExtraRows", 0, "Number of extra ordinary rows.");
+            extraRows = Config.Bind<int>("Toggles", "ExtraRows", 2, "Number of extra ordinary rows.");
             addEquipmentRow = Config.Bind<bool>("Toggles", "AddEquipmentRow", true, "Add special row for equipped items and quick slots.");
             displayEquipmentRowSeparate = Config.Bind<bool>("Toggles", "DisplayEquipmentRowSeparate", true, "Display equipment and quickslots in their own area.");
 
@@ -653,9 +653,9 @@ namespace ExtendedPlayerInventory
             if (hudRoot.Find("QuickAccessBar")?.GetComponent<RectTransform>() != null)
             {
                 if (quickAccessX.Value == 9999)
-                    quickAccessX.Value = hudRoot.Find("healthpanel").GetComponent<RectTransform>().anchoredPosition.x - 32;
+                    quickAccessX.Value = hudRoot.Find("healthpanel").GetComponent<RectTransform>().anchoredPosition.x + 170;
                 if (quickAccessY.Value == 9999)
-                    quickAccessY.Value = hudRoot.Find("healthpanel").GetComponent<RectTransform>().anchoredPosition.y - 870;
+                    quickAccessY.Value = hudRoot.Find("healthpanel").GetComponent<RectTransform>().anchoredPosition.y - 1203;
 
                 hudRoot.Find("QuickAccessBar").GetComponent<RectTransform>().anchoredPosition = new Vector2(quickAccessX.Value, quickAccessY.Value);
                 hudRoot.Find("QuickAccessBar").GetComponent<RectTransform>().localScale = new Vector3(quickAccessScale.Value, quickAccessScale.Value, 1);


### PR DESCRIPTION
As the name of the mod suggests, people install it to have an inventory boost. Setting the default to "0" just makes the process more difficult to use, requiring manual configuration.

The quick-use slots in the middle of the screen don't make for a pleasant experience.

Changes:

Set default number of extra ordinary rows: 2
Set new position of quick slots for better interface experience.