### PR TITLE
Fix CraftFromContainers mod following Valheim update

### DIFF
--- a/CraftFromContainers/BepInExPlugin.cs
+++ b/CraftFromContainers/BepInExPlugin.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -631,7 +632,7 @@ namespace CraftFromContainers
                     {
                         return;
                     }
-                    Text text = elementRoot.transform.Find("res_amount").GetComponent<Text>();
+                    TMP_Text text = elementRoot.transform.Find("res_amount").GetComponent<TMP_Text>();
                     if (invAmount < amount)
                     {
                         foreach (Container c in GetNearbyContainers(Player.m_localPlayer.transform.position))
@@ -644,7 +645,6 @@ namespace CraftFromContainers
                         text.text = string.Format(resourceString.Value, invAmount, amount);
                     else
                         text.text = amount.ToString();
-                    text.resizeTextForBestFit = true;
                 }
             }
         }

--- a/CraftFromContainers/BepInExPlugin.cs
+++ b/CraftFromContainers/BepInExPlugin.cs
@@ -13,7 +13,7 @@ using UnityEngine;
 
 namespace CraftFromContainers
 {
-    [BepInPlugin("aedenthorn.CraftFromContainers", "Craft From Containers", "3.4.0")]
+    [BepInPlugin("aedenthorn.CraftFromContainers", "Craft From Containers", "3.4.1")]
     public class BepInExPlugin: BaseUnityPlugin
     {
         private static bool wasAllowed;

--- a/CraftFromContainers/BepInExPlugin.cs
+++ b/CraftFromContainers/BepInExPlugin.cs
@@ -10,7 +10,6 @@ using System.Reflection;
 using System.Reflection.Emit;
 using TMPro;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace CraftFromContainers
 {


### PR DESCRIPTION
Fix CraftFromContainers mod following Valheim update.

Valheim component requirement text is now TMP_Text, not Text. Should be centered by default.