### PR TITLE
fix(BuildingDamageMod): zdoid matches attack again for user damage to their buildings

### DIFF
--- a/BuildingDamageMod/BepInExPlugin.cs
+++ b/BuildingDamageMod/BepInExPlugin.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 
 namespace BuildingDamageMod
 {
-    [BepInPlugin("aedenthorn.BuildingDamageMod", "Building Damage Mod", "0.5.1")]
+    [BepInPlugin("aedenthorn.BuildingDamageMod", "Building Damage Mod", "0.5.2")]
     public class BepInExPlugin: BaseUnityPlugin
     {
         private static readonly bool isDebug = true;
@@ -99,7 +99,9 @@ namespace BuildingDamageMod
                     {
                         mult = uncreatedDamageMult.Value;
                     }
-                    else if(hit.m_attacker.UserID == ___m_piece?.GetCreator())
+                    else if(___m_piece != null &&
+                         hit.m_attacker == Player.m_localPlayer.GetZDOID() &&
+                         ___m_piece.IsCreator())
                     {
                         mult = creatorDamageMult.Value;
                     }

--- a/BuildingDamageMod/BepInExPlugin.cs
+++ b/BuildingDamageMod/BepInExPlugin.cs
@@ -99,9 +99,8 @@ namespace BuildingDamageMod
                     {
                         mult = uncreatedDamageMult.Value;
                     }
-                    else if(___m_piece != null &&
-                         hit.m_attacker == Player.m_localPlayer.GetZDOID() &&
-                         ___m_piece.IsCreator())
+                    else if (hit.m_attacker == Player.m_localPlayer.GetZDOID() &&
+                         ___m_piece?.IsCreator())
                     {
                         mult = creatorDamageMult.Value;
                     }

--- a/BuildingDamageMod/BepInExPlugin.cs
+++ b/BuildingDamageMod/BepInExPlugin.cs
@@ -99,8 +99,8 @@ namespace BuildingDamageMod
                     {
                         mult = uncreatedDamageMult.Value;
                     }
-                    else if (hit.m_attacker == Player.m_localPlayer.GetZDOID() &&
-                         ___m_piece?.IsCreator())
+                    else if (hit.m_attacker == Player.m_localPlayer.GetZDOID() && ___m_piece != null &&
+                         ___m_piece.IsCreator())
                     {
                         mult = creatorDamageMult.Value;
                     }


### PR DESCRIPTION
m_piece changed from ZDOID to a long int version so there was a mismatch making this section always false.

We now have to do a user check with ZDOID comparison to the attacker (for server reasons) and check if the long int matches the users PlayerID long int value.