### PR TITLE
Fix for certain textures not being replaced on scene startup

### DIFF
--- a/CustomTextures/Patches.cs
+++ b/CustomTextures/Patches.cs
@@ -112,6 +112,7 @@ namespace CustomTextures
                     stopwatch.Restart();
 
                     ReplaceLocationTextures();
+                    ReloadTextures(reloadLocationTextures.Value && replaceLocationTextures.Value);
 
                     LogStopwatch("ZoneSystem Locations");
                 }


### PR DESCRIPTION
Solved a problem where certain textures like mist were only replaced after a manual reload