### PR TITLE
Fix ExtendedPlayerInventory poor performance

### DIFF
--- a/ExtendedPlayerInventory/BepInExPlugin.cs
+++ b/ExtendedPlayerInventory/BepInExPlugin.cs
@@ -633,8 +633,14 @@ namespace ExtendedPlayerInventory
                 if (!modEnabled.Value || !addEquipmentRow.Value || Player.m_localPlayer == null)
                     return;
 
-                float gameScale = __instance.GetComponent<CanvasScaler>().scaleFactor;
+                if (__instance == null)
+                    return;
 
+                CanvasScaler canvasScaler = __instance.GetComponent<CanvasScaler>();
+                if (canvasScaler == null)
+                    return;
+
+                float gameScale = canvasScaler.scaleFactor;
                 Vector3 mousePos = Input.mousePosition;
 
                 if (!modEnabled.Value)
@@ -648,25 +654,30 @@ namespace ExtendedPlayerInventory
                 if (lastMousePos == Vector3.zero)
                     lastMousePos = mousePos;
 
+                if (Hud.instance == null)
+                    return;
 
                 Transform hudRoot = Hud.instance.transform.Find("hudroot");
-
+                if (hudRoot == null)
+                    return;
 
                 if (AedenthornUtils.CheckKeyHeld(modKeyOne.Value) && AedenthornUtils.CheckKeyHeld(modKeyTwo.Value))
                 {
+                    Transform quickAccessBar = hudRoot.Find("QuickAccessBar");
+                    if (quickAccessBar == null)
+                        return;
 
-                   
-                    Rect quickSlotsRect = Rect.zero;
-                    if (hudRoot.Find("QuickAccessBar")?.GetComponent<RectTransform>() != null)
-                    {
-                        quickSlotsRect = new Rect(
-                            hudRoot.Find("QuickAccessBar").GetComponent<RectTransform>().anchoredPosition.x * gameScale,
-                            hudRoot.Find("QuickAccessBar").GetComponent<RectTransform>().anchoredPosition.y * gameScale + Screen.height - hudRoot.Find("QuickAccessBar").GetComponent<RectTransform>().sizeDelta.y * gameScale * quickAccessScale.Value,
-                            hudRoot.Find("QuickAccessBar").GetComponent<RectTransform>().sizeDelta.x * gameScale * quickAccessScale.Value * (3 / 8f),
-                            hudRoot.Find("QuickAccessBar").GetComponent<RectTransform>().sizeDelta.y * gameScale * quickAccessScale.Value
-                        );
-                    }
-                    
+                    RectTransform quickAccessRectTransform = quickAccessBar.GetComponent<RectTransform>();
+                    if (quickAccessRectTransform == null)
+                        return;
+
+                    Rect quickSlotsRect = new Rect(
+                        quickAccessRectTransform.anchoredPosition.x * gameScale,
+                        quickAccessRectTransform.anchoredPosition.y * gameScale + Screen.height - quickAccessRectTransform.sizeDelta.y * gameScale * quickAccessScale.Value,
+                        quickAccessRectTransform.sizeDelta.x * gameScale * quickAccessScale.Value * (3 / 8f),
+                        quickAccessRectTransform.sizeDelta.y * gameScale * quickAccessScale.Value
+                    );
+
                     if (quickSlotsRect.Contains(lastMousePos) && (currentlyDragging == "" || currentlyDragging == "QuickAccessBar"))
                     {
                         quickAccessX.Value += (mousePos.x - lastMousePos.x) / gameScale;
@@ -679,7 +690,9 @@ namespace ExtendedPlayerInventory
                     }
                 }
                 else
+                {
                     currentlyDragging = "";
+                }
 
                 lastMousePos = mousePos;
             }


### PR DESCRIPTION
# Background

ExtendedPlayerInventory tanks client performance.

This was due to constant exception handling (Null Pointer Exception).

This commit has no intended functional changes other than adding null pointer checks where the constant null pointer exception handling was occuring.

**The unintended functional change is the v, b, n UI moves from the center of the screen (which I do not believe is by design), to the left of the screen, vertically centered (see screenshots below).**

I can provide more version, mod details if needed, but given the safety of these changes, I don't find it necessary.

# Testing

Before:

![image](https://github.com/user-attachments/assets/73fe4eb5-cefd-4177-b36d-02f8524ca234)

![image](https://github.com/user-attachments/assets/9d1cfc1e-90d7-4eb0-8861-49058175cd0d)

After:

(Errors no longer spamming the logs)

```
[Info   : Unity Log] ExtendedPlayerInventory InventoryGui Show
[Info   : Unity Log] 03/22/2025 12:57:23: Setting selected recipe 0

[Info   : Unity Log] ExtendedPlayerInventory InventoryGui Show
```

![image](https://github.com/user-attachments/assets/e1805709-45a2-4595-baf4-1645f5593719)
